### PR TITLE
Errors not exceptions

### DIFF
--- a/BerTlv.xcodeproj/project.pbxproj
+++ b/BerTlv.xcodeproj/project.pbxproj
@@ -613,7 +613,6 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				FRAMEWORK_SEARCH_PATHS = (
-					"$(SDKROOT)/Developer/Library/Frameworks",
 					"$(inherited)",
 					"$(DEVELOPER_FRAMEWORKS_DIR)",
 				);
@@ -634,7 +633,6 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				FRAMEWORK_SEARCH_PATHS = (
-					"$(SDKROOT)/Developer/Library/Frameworks",
 					"$(inherited)",
 					"$(DEVELOPER_FRAMEWORKS_DIR)",
 				);

--- a/BerTlv.xcodeproj/project.pbxproj
+++ b/BerTlv.xcodeproj/project.pbxproj
@@ -10,6 +10,7 @@
 		4BE6176E1F56BE9700F9CBD4 /* BerTlvErrors.h in Headers */ = {isa = PBXBuildFile; fileRef = 4BE6176C1F56BE9700F9CBD4 /* BerTlvErrors.h */; };
 		4BE6176F1F56BE9700F9CBD4 /* BerTlvErrors.m in Sources */ = {isa = PBXBuildFile; fileRef = 4BE6176D1F56BE9700F9CBD4 /* BerTlvErrors.m */; };
 		4BE617701F56BF1D00F9CBD4 /* BerTlvErrors.m in Sources */ = {isa = PBXBuildFile; fileRef = 4BE6176D1F56BE9700F9CBD4 /* BerTlvErrors.m */; };
+		4BE617751F56F00000F9CBD4 /* BerTlvGarbageDataTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 4BE617741F56F00000F9CBD4 /* BerTlvGarbageDataTests.m */; };
 		8A4BEB4F198ED6C500707046 /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 8A4BEB4E198ED6C500707046 /* Foundation.framework */; };
 		8A4BEB54198ED6C500707046 /* BerTlv.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = 8A4BEB53198ED6C500707046 /* BerTlv.h */; };
 		8A4BEB56198ED6C500707046 /* BerTlv.m in Sources */ = {isa = PBXBuildFile; fileRef = 8A4BEB55198ED6C500707046 /* BerTlv.m */; };
@@ -80,6 +81,7 @@
 		4B9E63381E82B31E0051EA01 /* BerTlv.modulemap */ = {isa = PBXFileReference; lastKnownFileType = "sourcecode.module-map"; path = BerTlv.modulemap; sourceTree = "<group>"; };
 		4BE6176C1F56BE9700F9CBD4 /* BerTlvErrors.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = BerTlvErrors.h; sourceTree = "<group>"; };
 		4BE6176D1F56BE9700F9CBD4 /* BerTlvErrors.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = BerTlvErrors.m; sourceTree = "<group>"; };
+		4BE617741F56F00000F9CBD4 /* BerTlvGarbageDataTests.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = BerTlvGarbageDataTests.m; sourceTree = "<group>"; };
 		8A4BEB4B198ED6C500707046 /* libBerTlvStatic.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = libBerTlvStatic.a; sourceTree = BUILT_PRODUCTS_DIR; };
 		8A4BEB4E198ED6C500707046 /* Foundation.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Foundation.framework; path = System/Library/Frameworks/Foundation.framework; sourceTree = SDKROOT; };
 		8A4BEB52198ED6C500707046 /* BerTlv-Prefix.pch */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "BerTlv-Prefix.pch"; sourceTree = "<group>"; };
@@ -227,6 +229,7 @@
 				B2DF60961F8D8EF9A49F457B /* BerTlvParserTests.m */,
 				B2DF6D4ED74F7E2C04459B89 /* BerTlvsTests.m */,
 				B2DF6DFB3D566DBD8B474A49 /* BerTlvBuilderTests.m */,
+				4BE617741F56F00000F9CBD4 /* BerTlvGarbageDataTests.m */,
 			);
 			path = BerTlvTests;
 			sourceTree = "<group>";
@@ -438,6 +441,7 @@
 				B2DF65E3590F35608BF654D3 /* BerTlvParserTests.m in Sources */,
 				B2DF65529F987575E4CEFAC5 /* BerTlvsTests.m in Sources */,
 				B2DF6396CCD74FFB97269FE7 /* BerTlvBuilderTests.m in Sources */,
+				4BE617751F56F00000F9CBD4 /* BerTlvGarbageDataTests.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/BerTlv.xcodeproj/project.pbxproj
+++ b/BerTlv.xcodeproj/project.pbxproj
@@ -7,6 +7,9 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		4BE6176E1F56BE9700F9CBD4 /* BerTlvErrors.h in Headers */ = {isa = PBXBuildFile; fileRef = 4BE6176C1F56BE9700F9CBD4 /* BerTlvErrors.h */; };
+		4BE6176F1F56BE9700F9CBD4 /* BerTlvErrors.m in Sources */ = {isa = PBXBuildFile; fileRef = 4BE6176D1F56BE9700F9CBD4 /* BerTlvErrors.m */; };
+		4BE617701F56BF1D00F9CBD4 /* BerTlvErrors.m in Sources */ = {isa = PBXBuildFile; fileRef = 4BE6176D1F56BE9700F9CBD4 /* BerTlvErrors.m */; };
 		8A4BEB4F198ED6C500707046 /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 8A4BEB4E198ED6C500707046 /* Foundation.framework */; };
 		8A4BEB54198ED6C500707046 /* BerTlv.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = 8A4BEB53198ED6C500707046 /* BerTlv.h */; };
 		8A4BEB56198ED6C500707046 /* BerTlv.m in Sources */ = {isa = PBXBuildFile; fileRef = 8A4BEB55198ED6C500707046 /* BerTlv.m */; };
@@ -75,6 +78,8 @@
 
 /* Begin PBXFileReference section */
 		4B9E63381E82B31E0051EA01 /* BerTlv.modulemap */ = {isa = PBXFileReference; lastKnownFileType = "sourcecode.module-map"; path = BerTlv.modulemap; sourceTree = "<group>"; };
+		4BE6176C1F56BE9700F9CBD4 /* BerTlvErrors.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = BerTlvErrors.h; sourceTree = "<group>"; };
+		4BE6176D1F56BE9700F9CBD4 /* BerTlvErrors.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = BerTlvErrors.m; sourceTree = "<group>"; };
 		8A4BEB4B198ED6C500707046 /* libBerTlvStatic.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = libBerTlvStatic.a; sourceTree = BUILT_PRODUCTS_DIR; };
 		8A4BEB4E198ED6C500707046 /* Foundation.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Foundation.framework; path = System/Library/Frameworks/Foundation.framework; sourceTree = SDKROOT; };
 		8A4BEB52198ED6C500707046 /* BerTlv-Prefix.pch */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "BerTlv-Prefix.pch"; sourceTree = "<group>"; };
@@ -197,6 +202,8 @@
 				B2DF63B1FB5A3356C6A8BC63 /* BerTlvs.h */,
 				B2DF6CCDBA6480154AAA66AF /* BerTlvBuilder.m */,
 				B2DF630FA0DFAAEE5267F33E /* BerTlvBuilder.h */,
+				4BE6176C1F56BE9700F9CBD4 /* BerTlvErrors.h */,
+				4BE6176D1F56BE9700F9CBD4 /* BerTlvErrors.m */,
 			);
 			path = BerTlv;
 			sourceTree = "<group>";
@@ -257,6 +264,7 @@
 			isa = PBXHeadersBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				4BE6176E1F56BE9700F9CBD4 /* BerTlvErrors.h in Headers */,
 				8A858F501CE6156E00A3779C /* BerTag.h in Headers */,
 				8A858F521CE6156E00A3779C /* BerTlvParser.h in Headers */,
 				8A858F531CE6156E00A3779C /* BerTlvs.h in Headers */,
@@ -347,7 +355,7 @@
 		8A4BEB43198ED6C500707046 /* Project object */ = {
 			isa = PBXProject;
 			attributes = {
-				LastUpgradeCheck = 0510;
+				LastUpgradeCheck = 0900;
 				ORGANIZATIONNAME = "Evgeniy Sinev";
 				TargetAttributes = {
 					8A858F381CE6154600A3779C = {
@@ -416,6 +424,7 @@
 				B2DF61176FCB84C2ED25ADD5 /* BerTlvParser.m in Sources */,
 				B2DF65C52F004A588C3D3492 /* BerTlvs.m in Sources */,
 				B2DF6CF3341C45AA3C342B70 /* BerTlvBuilder.m in Sources */,
+				4BE617701F56BF1D00F9CBD4 /* BerTlvErrors.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -442,6 +451,7 @@
 				8A858F581CE6159100A3779C /* BerTlvParser.m in Sources */,
 				8A858F591CE6159100A3779C /* BerTlvs.m in Sources */,
 				8A858F5A1CE6159100A3779C /* BerTlvBuilder.m in Sources */,
+				4BE6176F1F56BE9700F9CBD4 /* BerTlvErrors.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -488,17 +498,29 @@
 				CLANG_CXX_LIBRARY = "libc++";
 				CLANG_ENABLE_MODULES = YES;
 				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
 				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_COMMA = YES;
 				CLANG_WARN_CONSTANT_CONVERSION = YES;
 				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
 				CLANG_WARN_EMPTY_BODY = YES;
 				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
 				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
 				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+				CLANG_WARN_STRICT_PROTOTYPES = YES;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
 				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
 				COPY_PHASE_STRIP = NO;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				ENABLE_TESTABILITY = YES;
 				GCC_C_LANGUAGE_STANDARD = gnu99;
 				GCC_DYNAMIC_NO_PIC = NO;
+				GCC_NO_COMMON_BLOCKS = YES;
 				GCC_OPTIMIZATION_LEVEL = 0;
 				GCC_PREPROCESSOR_DEFINITIONS = (
 					"DEBUG=1",
@@ -525,17 +547,28 @@
 				CLANG_CXX_LIBRARY = "libc++";
 				CLANG_ENABLE_MODULES = YES;
 				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
 				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_COMMA = YES;
 				CLANG_WARN_CONSTANT_CONVERSION = YES;
 				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
 				CLANG_WARN_EMPTY_BODY = YES;
 				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
 				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
 				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+				CLANG_WARN_STRICT_PROTOTYPES = YES;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
 				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
 				COPY_PHASE_STRIP = YES;
 				ENABLE_NS_ASSERTIONS = NO;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
 				GCC_C_LANGUAGE_STANDARD = gnu99;
+				GCC_NO_COMMON_BLOCKS = YES;
 				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
 				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
 				GCC_WARN_UNDECLARED_SELECTOR = YES;
@@ -587,6 +620,7 @@
 					"$(inherited)",
 				);
 				INFOPLIST_FILE = "BerTlvTests/BerTlvTests-Info.plist";
+				PRODUCT_BUNDLE_IDENTIFIER = "com.payneteasy.${PRODUCT_NAME:rfc1034identifier}";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				WRAPPER_EXTENSION = xctest;
 			};
@@ -603,6 +637,7 @@
 				GCC_PRECOMPILE_PREFIX_HEADER = YES;
 				GCC_PREFIX_HEADER = "BerTlv/BerTlv-Prefix.pch";
 				INFOPLIST_FILE = "BerTlvTests/BerTlvTests-Info.plist";
+				PRODUCT_BUNDLE_IDENTIFIER = "com.payneteasy.${PRODUCT_NAME:rfc1034identifier}";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				WRAPPER_EXTENSION = xctest;
 			};
@@ -613,7 +648,7 @@
 			buildSettings = {
 				CLANG_ANALYZER_NONNULL = YES;
 				CLANG_WARN_UNREACHABLE_CODE = YES;
-				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
 				CURRENT_PROJECT_VERSION = 1;
 				DEBUG_INFORMATION_FORMAT = dwarf;
 				DEFINES_MODULE = YES;
@@ -644,7 +679,7 @@
 			buildSettings = {
 				CLANG_ANALYZER_NONNULL = YES;
 				CLANG_WARN_UNREACHABLE_CODE = YES;
-				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
 				COPY_PHASE_STRIP = NO;
 				CURRENT_PROJECT_VERSION = 1;
 				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";

--- a/BerTlv.xcodeproj/xcshareddata/xcschemes/BerTlv.xcscheme
+++ b/BerTlv.xcodeproj/xcshareddata/xcschemes/BerTlv.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "0730"
+   LastUpgradeVersion = "0900"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"
@@ -26,6 +26,7 @@
       buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      language = ""
       shouldUseLaunchSchemeArgsEnv = "YES">
       <Testables>
          <TestableReference
@@ -55,6 +56,7 @@
       buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      language = ""
       launchStyle = "0"
       useCustomWorkingDirectory = "NO"
       ignoresPersistentStateOnLaunch = "NO"

--- a/BerTlv/BerTag.h
+++ b/BerTlv/BerTag.h
@@ -5,11 +5,12 @@
 
 #import <Foundation/Foundation.h>
 
+NS_ASSUME_NONNULL_BEGIN
 @interface BerTag : NSObject
 
 @property(nonatomic, copy) NSData *data;;
 
-- (id) init:(NSData *)aData
+- (id _Nullable) init:(NSData *)aData
      offset:(uint)aOffset
      length:(uint)aLength;
 
@@ -28,3 +29,4 @@
 
 + (BerTag *)parse:(NSString *)aHexString;
 @end
+NS_ASSUME_NONNULL_END

--- a/BerTlv/BerTag.m
+++ b/BerTlv/BerTag.m
@@ -15,8 +15,12 @@
 - (id)init:(NSData *)aData offset:(uint)aOffset length:(uint)aLength {
     self = [super init];
     if(self) {
-        NSRange range = {aOffset, aLength};
-        data = [aData subdataWithRange:range];
+        if (aOffset + aLength <= aData.length) {
+            NSRange range = {aOffset, aLength};
+            data = [aData subdataWithRange:range];
+        } else {
+            return nil;
+        }
     }
     return self;
 }
@@ -53,6 +57,7 @@
 }
 
 - (BOOL)isConstructed {
+    if (!data) return true;
     uint8_t *bytes = (uint8_t *) data.bytes;
     // 0x20
     return (bytes[0] & 0b00100000) != 0;

--- a/BerTlv/BerTlv.h
+++ b/BerTlv/BerTlv.h
@@ -26,7 +26,7 @@ NS_ASSUME_NONNULL_BEGIN
 - (BerTlv * _Nullable)  find:(BerTag *)aTag;
 - (NSArray *) findAll:(BerTag *)aTag;
 
-- (NSString * _Nullable) hexValueWithError:(NSError **)error;
+- (NSString * _Nullable) hexValue;
 - (NSString * _Nullable) textValue;
 
 - (NSString *) dump:(NSString *)aPadding;

--- a/BerTlv/BerTlv.h
+++ b/BerTlv/BerTlv.h
@@ -8,6 +8,7 @@
 
 #import <Foundation/Foundation.h>
 
+NS_ASSUME_NONNULL_BEGIN
 @class BerTag;
 
 @interface BerTlv : NSObject
@@ -22,12 +23,13 @@
 - (id)init:(BerTag *)aTag array:(NSArray *)aArray;
 
 - (BOOL)      hasTag:(BerTag *)aTag;
-- (BerTlv *)  find:(BerTag *)aTag;
+- (BerTlv * _Nullable)  find:(BerTag *)aTag;
 - (NSArray *) findAll:(BerTag *)aTag;
 
-- (NSString *) hexValue;
-- (NSString *) textValue;
+- (NSString * _Nullable) hexValueWithError:(NSError **)error;
+- (NSString * _Nullable) textValue;
 
 - (NSString *) dump:(NSString *)aPadding;
 
 @end
+NS_ASSUME_NONNULL_END

--- a/BerTlv/BerTlv.m
+++ b/BerTlv/BerTlv.m
@@ -76,11 +76,9 @@
     return array;
 }
 
-- (NSString *)hexValueWithError:(NSError **)error {
+- (NSString *)hexValue {
     if (constructed) {
-        if (error) {
-            *error = [BerTlvErrors tagNotPrimative:tag];
-        }
+        NSLog(@"Tag %@ is constructed", tag);
         return nil;
     } else {
         return [HexUtil format:value];
@@ -95,7 +93,7 @@
     NSMutableString *sb = [[NSMutableString alloc] init];
 
     if(primitive) {
-        [sb appendFormat:@"%@ - [%@] %@\n", aPadding, tag.hex, [self hexValueWithError:nil]];
+        [sb appendFormat:@"%@ - [%@] %@\n", aPadding, tag.hex, [self hexValue]];
     } else {
         [sb appendFormat:@"%@ + [%@]\n", aPadding, tag.hex];
         NSMutableString *childPadding = [[NSMutableString alloc] init];

--- a/BerTlv/BerTlvBuilder.h
+++ b/BerTlv/BerTlvBuilder.h
@@ -10,6 +10,7 @@
 @class BerTag;
 
 
+NS_ASSUME_NONNULL_BEGIN
 @interface BerTlvBuilder : NSObject
 
 // initialize
@@ -35,3 +36,4 @@
 - (void) addHex     :(NSString   *) aHex     tag:(BerTag *)aTag;
 
 @end
+NS_ASSUME_NONNULL_END

--- a/BerTlv/BerTlvBuilder.h
+++ b/BerTlv/BerTlvBuilder.h
@@ -20,20 +20,21 @@ NS_ASSUME_NONNULL_BEGIN
 - (id)initWithTemplate :(BerTag  * ) aTag  ;
 
 // build
-- (NSData  *) buildData ;
-- (BerTlvs *) buildTlvs ;
-- (BerTlv  *) buildTlv  ;
+- (NSData  * _Nullable) buildDataWithError:(NSError **)error  ;
+- (BerTlvs * _Nullable) buildTlvsWithError:(NSError **)error  ;
+- (BerTlv  * _Nullable) buildTlvWithError:(NSError **)error   ;
 
 // add values
-- (void) addBerTlv  :(BerTlv     *) aTlv ;
-- (void) addBerTlvs :(BerTlvs    *) aTlvs;
-- (void) addAmount  :(NSDecimalNumber  *) aAmount  tag:(BerTag *)aTag;
+// return BOOL indicates success
+- (BOOL) addBerTlv  :(BerTlv     *) aTlv ;
+- (BOOL) addBerTlvs :(BerTlvs    *) aTlvs;
+- (BOOL) addAmount  :(NSDecimalNumber  *) aAmount  tag:(BerTag *)aTag;
 - (void) addDate    :(NSDate     *) aDate    tag:(BerTag *)aTag;
 - (void) addTime    :(NSDate     *) aTime    tag:(BerTag *)aTag;
-- (void) addText    :(NSString   *) aText    tag:(BerTag *)aTag;
-- (void) addBcd     :(NSUInteger  ) aValue   tag:(BerTag *)aTag length:(NSUInteger )aLength;
-- (void) addBytes   :(NSData     *) aBuf     tag:(BerTag *)aTag;
-- (void) addHex     :(NSString   *) aHex     tag:(BerTag *)aTag;
+- (BOOL) addText    :(NSString   *) aText    tag:(BerTag *)aTag;
+- (BOOL) addBcd     :(NSUInteger  ) aValue   tag:(BerTag *)aTag length  :(NSUInteger )aLength;
+- (BOOL) addBytes   :(NSData     *) aBuf     tag:(BerTag *)aTag;
+- (BOOL) addHex     :(NSString   *) aHex     tag:(BerTag *)aTag;
 
 @end
 NS_ASSUME_NONNULL_END

--- a/BerTlv/BerTlvBuilder.m
+++ b/BerTlv/BerTlvBuilder.m
@@ -175,12 +175,12 @@
 
 - (BerTlv *)buildTlv {
     BerTlvParser * parser = [[BerTlvParser alloc] init];
-    return [parser parseConstructed:[self buildData]];
+    return [parser parseConstructed:[self buildData] error:nil];
 }
 
 - (BerTlvs *)buildTlvs {
     BerTlvParser * parser = [[BerTlvParser alloc] init];
-    return [parser parseTlvs:[self buildData]];
+    return [parser parseTlvs:[self buildData] error:nil];
 }
 
 - (NSUInteger) calcBytesCountForLength:(NSUInteger)aLength {

--- a/BerTlv/BerTlvErrors.h
+++ b/BerTlv/BerTlvErrors.h
@@ -1,7 +1,4 @@
 //
-//  BerTlvErrors.h
-//  BerTlv
-//
 //  Created by Alex Kent on 2017-08-30.
 //  Copyright © 2017 Evgeniy Sinev. All rights reserved.
 //
@@ -12,6 +9,8 @@ NS_ASSUME_NONNULL_BEGIN
 @interface BerTlvErrors : NSObject
 
 + (NSError *)invalidHexString;
++ (NSError *)outOfRangeAtOffset:(uint)aOffset length:(NSUInteger)aLen bufferLength:(NSUInteger)aBufLen level:(NSUInteger)aLevel;
++ (NSError *)badLengthAtOffset:(uint)aOffset numberOfBytes:(NSUInteger)numberOfBytes;
 
 @end
 NS_ASSUME_NONNULL_END

--- a/BerTlv/BerTlvErrors.h
+++ b/BerTlv/BerTlvErrors.h
@@ -1,0 +1,17 @@
+//
+//  BerTlvErrors.h
+//  BerTlv
+//
+//  Created by Alex Kent on 2017-08-30.
+//  Copyright © 2017 Evgeniy Sinev. All rights reserved.
+//
+
+#import <Foundation/Foundation.h>
+
+NS_ASSUME_NONNULL_BEGIN
+@interface BerTlvErrors : NSObject
+
++ (NSError *)invalidHexString;
+
+@end
+NS_ASSUME_NONNULL_END

--- a/BerTlv/BerTlvErrors.h
+++ b/BerTlv/BerTlvErrors.h
@@ -12,7 +12,6 @@ NS_ASSUME_NONNULL_BEGIN
 + (NSError *)invalidHexString;
 + (NSError *)outOfRangeAtOffset:(uint)aOffset length:(NSUInteger)aLen bufferLength:(NSUInteger)aBufLen level:(NSUInteger)aLevel;
 + (NSError *)badLengthAtOffset:(uint)aOffset numberOfBytes:(NSUInteger)numberOfBytes;
-+ (NSError *)tagNotPrimative:(BerTag *)aTag;
 
 @end
 NS_ASSUME_NONNULL_END

--- a/BerTlv/BerTlvErrors.h
+++ b/BerTlv/BerTlvErrors.h
@@ -4,6 +4,7 @@
 //
 
 #import <Foundation/Foundation.h>
+#import "BerTag.h"
 
 NS_ASSUME_NONNULL_BEGIN
 @interface BerTlvErrors : NSObject
@@ -11,6 +12,7 @@ NS_ASSUME_NONNULL_BEGIN
 + (NSError *)invalidHexString;
 + (NSError *)outOfRangeAtOffset:(uint)aOffset length:(NSUInteger)aLen bufferLength:(NSUInteger)aBufLen level:(NSUInteger)aLevel;
 + (NSError *)badLengthAtOffset:(uint)aOffset numberOfBytes:(NSUInteger)numberOfBytes;
++ (NSError *)tagNotPrimative:(BerTag *)aTag;
 
 @end
 NS_ASSUME_NONNULL_END

--- a/BerTlv/BerTlvErrors.h
+++ b/BerTlv/BerTlvErrors.h
@@ -12,6 +12,7 @@ NS_ASSUME_NONNULL_BEGIN
 + (NSError *)invalidHexString;
 + (NSError *)outOfRangeAtOffset:(uint)aOffset length:(NSUInteger)aLen bufferLength:(NSUInteger)aBufLen level:(NSUInteger)aLevel;
 + (NSError *)badLengthAtOffset:(uint)aOffset numberOfBytes:(NSUInteger)numberOfBytes;
++ (NSError *)lengthOutOfRange:(unsigned long)aLength;
 
 @end
 NS_ASSUME_NONNULL_END

--- a/BerTlv/BerTlvErrors.m
+++ b/BerTlv/BerTlvErrors.m
@@ -19,7 +19,11 @@
 
 
 + (NSError *)badLengthAtOffset:(uint)aOffset numberOfBytes:(NSUInteger)numberOfBytes {
-    return [[NSError alloc] initWithDomain:kBerTlvErrorDomain code:1 userInfo: @{NSLocalizedDescriptionKey : [NSString stringWithFormat:NSLocalizedString(@"At position %d the len is more then 3 [%d]", "Length is out of the range"), aOffset, numberOfBytes]}];
+    return [[NSError alloc] initWithDomain:kBerTlvErrorDomain code:2 userInfo: @{NSLocalizedDescriptionKey : [NSString stringWithFormat:NSLocalizedString(@"At position %d the len is more then 3 [%d]", "Length is out of the range"), aOffset, numberOfBytes]}];
+}
+
++ (NSError *)tagNotPrimative:(BerTag *)aTag {
+        return [[NSError alloc] initWithDomain:kBerTlvErrorDomain code:3 userInfo: @{NSLocalizedDescriptionKey : [NSString stringWithFormat:NSLocalizedString(@"Tag %@ is constructed", "Is not primative tag"), aTag]}];
 }
 
 @end

--- a/BerTlv/BerTlvErrors.m
+++ b/BerTlv/BerTlvErrors.m
@@ -1,17 +1,25 @@
 //
-//  BerTlvErrors.m
-//  BerTlv
-//
 //  Created by Alex Kent on 2017-08-30.
 //  Copyright © 2017 Evgeniy Sinev. All rights reserved.
 //
 
 #import "BerTlvErrors.h"
 
+#define kBerTlvErrorDomain @"com.payneteasy.BerTlvFramework"
+
 @implementation BerTlvErrors
 
 + (NSError *)invalidHexString {
-    return [[NSError alloc] initWithDomain:@"com.payneteasy.BerTlvFramework" code:2 userInfo: @{NSLocalizedDescriptionKey : NSLocalizedString(@"Invalid Hex string", "Invalid hex string")}];
+    return [[NSError alloc] initWithDomain:kBerTlvErrorDomain code:0 userInfo: @{NSLocalizedDescriptionKey : NSLocalizedString(@"Invalid Hex string", "Invalid hex string")}];
+}
+
++ (NSError *)outOfRangeAtOffset:(uint)aOffset length:(NSUInteger)aLen bufferLength:(NSUInteger)aBufLen level:(NSUInteger)aLevel {
+    return [[NSError alloc] initWithDomain:kBerTlvErrorDomain code:1 userInfo: @{NSLocalizedDescriptionKey : [NSString stringWithFormat:NSLocalizedString(@"Length is out of the range [offset=%d,  len=%d, array.length=%lu, level=%d]", "Length is out of the range"), aOffset, aLen, aBufLen, aLevel] }];
+}
+
+
++ (NSError *)badLengthAtOffset:(uint)aOffset numberOfBytes:(NSUInteger)numberOfBytes {
+    return [[NSError alloc] initWithDomain:kBerTlvErrorDomain code:1 userInfo: @{NSLocalizedDescriptionKey : [NSString stringWithFormat:NSLocalizedString(@"At position %d the len is more then 3 [%d]", "Length is out of the range"), aOffset, numberOfBytes]}];
 }
 
 @end

--- a/BerTlv/BerTlvErrors.m
+++ b/BerTlv/BerTlvErrors.m
@@ -22,8 +22,4 @@
     return [[NSError alloc] initWithDomain:kBerTlvErrorDomain code:2 userInfo: @{NSLocalizedDescriptionKey : [NSString stringWithFormat:NSLocalizedString(@"At position %d the len is more then 3 [%d]", "Length is out of the range"), aOffset, numberOfBytes]}];
 }
 
-+ (NSError *)tagNotPrimative:(BerTag *)aTag {
-        return [[NSError alloc] initWithDomain:kBerTlvErrorDomain code:3 userInfo: @{NSLocalizedDescriptionKey : [NSString stringWithFormat:NSLocalizedString(@"Tag %@ is constructed", "Is not primative tag"), aTag]}];
-}
-
 @end

--- a/BerTlv/BerTlvErrors.m
+++ b/BerTlv/BerTlvErrors.m
@@ -1,0 +1,17 @@
+//
+//  BerTlvErrors.m
+//  BerTlv
+//
+//  Created by Alex Kent on 2017-08-30.
+//  Copyright © 2017 Evgeniy Sinev. All rights reserved.
+//
+
+#import "BerTlvErrors.h"
+
+@implementation BerTlvErrors
+
++ (NSError *)invalidHexString {
+    return [[NSError alloc] initWithDomain:@"com.payneteasy.BerTlvFramework" code:2 userInfo: @{NSLocalizedDescriptionKey : NSLocalizedString(@"Invalid Hex string", "Invalid hex string")}];
+}
+
+@end

--- a/BerTlv/BerTlvErrors.m
+++ b/BerTlv/BerTlvErrors.m
@@ -10,16 +10,20 @@
 @implementation BerTlvErrors
 
 + (NSError *)invalidHexString {
-    return [[NSError alloc] initWithDomain:kBerTlvErrorDomain code:0 userInfo: @{NSLocalizedDescriptionKey : NSLocalizedString(@"Invalid Hex string", "Invalid hex string")}];
+    return [[NSError alloc] initWithDomain:kBerTlvErrorDomain code:0 userInfo: @{NSLocalizedDescriptionKey : NSLocalizedString(@"Invalid Hex string", "")}];
 }
 
 + (NSError *)outOfRangeAtOffset:(uint)aOffset length:(NSUInteger)aLen bufferLength:(NSUInteger)aBufLen level:(NSUInteger)aLevel {
-    return [[NSError alloc] initWithDomain:kBerTlvErrorDomain code:1 userInfo: @{NSLocalizedDescriptionKey : [NSString stringWithFormat:NSLocalizedString(@"Length is out of the range [offset=%d,  len=%d, array.length=%lu, level=%d]", "Length is out of the range"), aOffset, aLen, aBufLen, aLevel] }];
+    return [[NSError alloc] initWithDomain:kBerTlvErrorDomain code:1 userInfo: @{NSLocalizedDescriptionKey : [NSString stringWithFormat:NSLocalizedString(@"Length is out of the range [offset=%d,  len=%d, array.length=%lu, level=%d]", ""), aOffset, aLen, aBufLen, aLevel] }];
 }
 
 
 + (NSError *)badLengthAtOffset:(uint)aOffset numberOfBytes:(NSUInteger)numberOfBytes {
-    return [[NSError alloc] initWithDomain:kBerTlvErrorDomain code:2 userInfo: @{NSLocalizedDescriptionKey : [NSString stringWithFormat:NSLocalizedString(@"At position %d the len is more then 3 [%d]", "Length is out of the range"), aOffset, numberOfBytes]}];
+    return [[NSError alloc] initWithDomain:kBerTlvErrorDomain code:2 userInfo: @{NSLocalizedDescriptionKey : [NSString stringWithFormat:NSLocalizedString(@"At position %d the len is more then 3 [%d]", ""), aOffset, numberOfBytes]}];
+}
+
++ (NSError *)lengthOutOfRange:(unsigned long)aLength {
+    return [[NSError alloc] initWithDomain:kBerTlvErrorDomain code:2 userInfo: @{NSLocalizedDescriptionKey : [NSString stringWithFormat:NSLocalizedString(@"Length [%lu] is out of range ( > 0x1000000)", ""), aLength]}];
 }
 
 @end

--- a/BerTlv/BerTlvParser.h
+++ b/BerTlv/BerTlvParser.h
@@ -8,10 +8,11 @@
 @class BerTlv;
 @class BerTlvs;
 
-
+NS_ASSUME_NONNULL_BEGIN
 @interface BerTlvParser : NSObject
 
-- (BerTlv *)parseConstructed:(NSData *)aData;
-- (BerTlvs *)parseTlvs:(NSData *)aData;
-- (BerTlvs *)parseTlvs:(NSData *)aData numberOfTags:(NSUInteger)numberOfTags;
+- (BerTlv * _Nullable)parseConstructed:(NSData *)aData error:(NSError **)error;
+- (BerTlvs * _Nullable)parseTlvs:(NSData *)aData error:(NSError **)error;
+- (BerTlvs * _Nullable)parseTlvs:(NSData *)aData numberOfTags:(NSUInteger)numberOfTags error:(NSError **)error;
 @end
+NS_ASSUME_NONNULL_END

--- a/BerTlv/BerTlvParser.m
+++ b/BerTlv/BerTlvParser.m
@@ -98,6 +98,7 @@ static int IS_DEBUG_ENABLED = 0;
            dataBytesCount:lengthBytesCount
               valueLength:valueLength
                     array:array
+                    error:error
         ];
         uint resultOffset = aOffset + tagBytesCount + lengthBytesCount + valueLength;
         if(IS_DEBUG_ENABLED) {
@@ -207,6 +208,7 @@ static int IS_DEBUG_ENABLED = 0;
       dataBytesCount:(uint)aDataBytesCount
          valueLength:(uint)aValueLength
                array:(NSMutableArray *)aList
+               error:(NSError **)error
 {
 
     uint startPosition = aOffset + aTagBytesCount + aDataBytesCount;
@@ -214,9 +216,12 @@ static int IS_DEBUG_ENABLED = 0;
 
     while (startPosition < aOffset + aValueLength) {
         uint result = 0;
-        BerTlv *tlv = [self parseWithResult:&result data:aBuf offset:startPosition len:len level:aLevel+1 error:nil];
+        BerTlv *tlv = [self parseWithResult:&result data:aBuf offset:startPosition len:len level:aLevel+1 error:error];
         if (tlv != nil) {
             [aList addObject:tlv];
+        }
+        if (error) {
+            return;
         }
         
         startPosition = result;

--- a/BerTlv/BerTlvParser.m
+++ b/BerTlv/BerTlvParser.m
@@ -11,7 +11,7 @@
 #import "BerTlvErrors.h"
 
 
-static int IS_DEBUG_ENABLED = 0;
+static int IS_DEBUG_ENABLED = 0; // note, running the testFuzzer with this enabled will take a long time.
 
 @implementation BerTlvParser
 
@@ -45,10 +45,6 @@ static int IS_DEBUG_ENABLED = 0;
         }
 
         offset = result;
-        
-//        if (error) {
-//            break;
-//        }
     }
 
     return [[BerTlvs alloc] init:list];
@@ -223,9 +219,6 @@ static int IS_DEBUG_ENABLED = 0;
         BerTlv *tlv = [self parseWithResult:&result data:aBuf offset:startPosition len:len level:aLevel+1 error:error];
         if (tlv != nil) {
             [aList addObject:tlv];
-        }
-        if (error) {
-            return;
         }
         
         startPosition = result;

--- a/BerTlv/BerTlvs.h
+++ b/BerTlv/BerTlvs.h
@@ -8,17 +8,18 @@
 @class BerTag;
 @class BerTlv;
 
-
+NS_ASSUME_NONNULL_BEGIN
 @interface BerTlvs : NSObject
 
-@property(copy, nonatomic, readonly) NSArray *  list        ;
+@property(copy, nonatomic, readonly) NSArray *  list;
 
 - (id)init:(NSArray *)aList;
 
-- (BerTlv *)  find   :(BerTag *)aTag;
+- (BerTlv * _Nullable)  find   :(BerTag *)aTag;
 - (NSArray *) findAll:(BerTag *)aTag;
 
 - (NSString *) dump:(NSString *)aPadding;
 
 
 @end
+NS_ASSUME_NONNULL_END

--- a/BerTlv/BerTlvs.m
+++ b/BerTlv/BerTlvs.m
@@ -9,8 +9,7 @@
 
 
 @implementation BerTlvs {
-
-
+    
 }
 
 @synthesize list;

--- a/BerTlv/HexUtil.h
+++ b/BerTlv/HexUtil.h
@@ -17,4 +17,3 @@ NS_ASSUME_NONNULL_BEGIN
 + (NSString *)format:(NSData *)data offset:(uint)offset len:(NSUInteger)len;
 @end
 NS_ASSUME_NONNULL_END
-

--- a/BerTlv/HexUtil.h
+++ b/BerTlv/HexUtil.h
@@ -5,13 +5,16 @@
 
 #import <Foundation/Foundation.h>
 
-
+NS_ASSUME_NONNULL_BEGIN
 @interface HexUtil : NSObject
 
 + (NSString *) format:(NSData *)aData;
 + (NSString *) prettyFormat:(NSData *)aData;
 
-+ (NSData *) parse:(NSString *)aHex;
++ (NSData * _Nullable) parse:(NSString *)aHex;
++ (NSData *) parse:(NSString *)aHex error:(NSError **)error;
 
 + (NSString *)format:(NSData *)data offset:(uint)offset len:(NSUInteger)len;
 @end
+NS_ASSUME_NONNULL_END
+

--- a/BerTlv/HexUtil.m
+++ b/BerTlv/HexUtil.m
@@ -104,9 +104,11 @@ static uint8_t HEX_BYTE_SKIP = 99;
     NSMutableString *sb = [[NSMutableString alloc] initWithCapacity:aData.length*2];
     uint8_t const *bytes = aData.bytes;
     NSUInteger max = aOffset+aLen;
-    for(NSUInteger i=aOffset; i < max; i++) {
-        uint8_t b = bytes[i];
-        [sb appendFormat:@"%02X", b];
+    if (max <= aData.length) {
+        for(NSUInteger i=aOffset; i < max; i++) {
+            uint8_t b = bytes[i];
+            [sb appendFormat:@"%02X", b];
+        }
     }
     return [sb copy];
 }

--- a/BerTlv/HexUtil.m
+++ b/BerTlv/HexUtil.m
@@ -22,8 +22,6 @@ static uint8_t HEX_BYTE_SKIP = 99;
 
 
 @implementation HexUtil {
-
-
 }
 
 + (NSString *)prettyFormat:(NSData *)aData {
@@ -34,7 +32,7 @@ static uint8_t HEX_BYTE_SKIP = 99;
         uint8_t b = bytes[i];
         [sb appendFormat:@" %02X", b];
     }
-    return sb;
+    return [sb copy];
 }
 
 + (NSString *)format:(NSData *)aData {
@@ -42,6 +40,10 @@ static uint8_t HEX_BYTE_SKIP = 99;
 }
 
 + (NSData *)parse:(NSString *)aHex {
+    return [self parse:aHex error:nil];
+}
+
++ (NSData *) parse:(NSString *)aHex error:(NSError **)error {
     char const *text = [aHex cStringUsingEncoding:NSASCIIStringEncoding];
     size_t len = strnlen(text, aHex.length);
 
@@ -80,13 +82,21 @@ static uint8_t HEX_BYTE_SKIP = 99;
     }
 
     if(highPassed) {
-        @throw([NSException exceptionWithName:@"EvenException"
-                                       reason:[NSString stringWithFormat:@"Even count of HEX chars. Hex string is %@"
-                                               , aHex]
-                                     userInfo:nil]);
+        if (error) {
+            *error = [self invalidStringError];
+        }
+        return nil;
     }
-    // returns immutable
-    return [NSData dataWithData:data];
+    
+    if ([data length] == 0) {
+        if (error) {
+            *error = [self invalidStringError];
+        }
+        return nil;
+    } else {
+        // returns immutable
+        return [data copy];
+    }
 }
 
 
@@ -98,6 +108,10 @@ static uint8_t HEX_BYTE_SKIP = 99;
         uint8_t b = bytes[i];
         [sb appendFormat:@"%02X", b];
     }
-    return sb;
+    return [sb copy];
+}
+
++ (NSError *)invalidStringError {
+    return [[NSError alloc] initWithDomain:@"com.payneteasy.BerTlvFramework" code:2 userInfo: @{NSLocalizedDescriptionKey : NSLocalizedString(@"Invalid Hex string", "Invalid hex string")}];
 }
 @end

--- a/BerTlv/HexUtil.m
+++ b/BerTlv/HexUtil.m
@@ -4,6 +4,7 @@
 //
 
 #import "HexUtil.h"
+#import "BerTlvErrors.h"
 
 static uint8_t HEX_BYTES[] = {
        // 0   1   2   3   4   5   6   7   8   9   A   B   C   D   E   F
@@ -21,8 +22,7 @@ static uint8_t HEX_BYTES_LEN = 128;
 static uint8_t HEX_BYTE_SKIP = 99;
 
 
-@implementation HexUtil {
-}
+@implementation HexUtil
 
 + (NSString *)prettyFormat:(NSData *)aData {
     NSMutableString *sb = [[NSMutableString alloc] initWithCapacity:aData.length*2];
@@ -83,14 +83,14 @@ static uint8_t HEX_BYTE_SKIP = 99;
 
     if(highPassed) {
         if (error) {
-            *error = [self invalidStringError];
+            *error = [BerTlvErrors invalidHexString];
         }
         return nil;
     }
     
     if ([data length] == 0) {
         if (error) {
-            *error = [self invalidStringError];
+            *error = [BerTlvErrors invalidHexString];
         }
         return nil;
     } else {
@@ -111,7 +111,4 @@ static uint8_t HEX_BYTE_SKIP = 99;
     return [sb copy];
 }
 
-+ (NSError *)invalidStringError {
-    return [[NSError alloc] initWithDomain:@"com.payneteasy.BerTlvFramework" code:2 userInfo: @{NSLocalizedDescriptionKey : NSLocalizedString(@"Invalid Hex string", "Invalid hex string")}];
-}
 @end

--- a/BerTlvTests/BerTlvGarbageDataTests.m
+++ b/BerTlvTests/BerTlvGarbageDataTests.m
@@ -22,7 +22,7 @@
 - (void)testHexValueOnConstructedTagLogsError {
     BerTag *tag = [[BerTag alloc] init:0xff];
     BerTlv *tlv = [[BerTlv alloc] init:tag array:@[]];
-    NSString *hexValue = [tlv hexValueWithError:nil];
+    NSString *hexValue = [tlv hexValue];
     
     XCTAssertNil(hexValue);
 }

--- a/BerTlvTests/BerTlvGarbageDataTests.m
+++ b/BerTlvTests/BerTlvGarbageDataTests.m
@@ -63,7 +63,7 @@
     BerTlvParser *parser = [[BerTlvParser alloc] init];
 
     NSInteger maxSize = 2048;
-    NSInteger count = 1000; // increase this number to run the fuzzer longer.
+    NSInteger count = 10000; // increase this number to run the fuzzer longer.
     NSInteger failCount = 0;
 
     for (NSInteger i = 0; i < count; i++) {
@@ -78,7 +78,9 @@
             failCount++;
         }
         double timePassed_ms = [startTime timeIntervalSinceNow] * -1000.0;
-        NSLog(@"Took %f", timePassed_ms);
+        if (timePassed_ms > 1.0) {
+            NSLog(@"Took suspiciously long (%fs) to parse:\n%@", timePassed_ms, rndData);
+        }
     }
     NSLog(@"fuzzer crashed %ld from %ld runs, with max length %ld", (long)failCount, (long)count, (long)maxSize);
 }

--- a/BerTlvTests/BerTlvGarbageDataTests.m
+++ b/BerTlvTests/BerTlvGarbageDataTests.m
@@ -1,0 +1,97 @@
+//
+//  akTests.m
+//  BerTlvTests
+//
+//  Created by Alex Kent on 04/08/2017.
+//  Copyright © 2017 Evgeniy Sinev. All rights reserved.
+//
+
+#import <XCTest/XCTest.h>
+#import "BerTag.h"
+#import "HexUtil.h"
+#import "BerTlvParser.h"
+#import "BerTlv.h"
+#import "BerTlvs.h"
+
+
+@interface BerTlvGarbageDataTests : XCTestCase
+@end
+
+@implementation BerTlvGarbageDataTests
+
+- (void)testHexValueOnConstructedTagLogsError {
+    BerTag *tag = [[BerTag alloc] init:0xff];
+    BerTlv *tlv = [[BerTlv alloc] init:tag array:@[]];
+    NSString *hexValue = [tlv hexValueWithError:nil];
+    
+    XCTAssertNil(hexValue);
+}
+
+- (void)testNSDataParseStringMiscountReturnsNil {
+    NSData *data = [HexUtil parse:@"fff"];
+    XCTAssertNil(data);
+}
+
+//- (void)testCalcDataBadLength {
+//    BerTlvParser *parser = [[BerTlvParser alloc] init];
+//    NSData *testData = [HexUtil parse:@"ff20ffff0000"];
+//    BerTlvs *result = [parser parseTlvs:testData error:nil];
+//
+//    XCTAssertEqual([[result list] count], 0);
+//}
+//
+//- (void)testOutOfRange {
+//    BerTlvParser *parser = [[BerTlvParser alloc] init];
+//    NSData *testData = [HexUtil parse:@"3f9f5745 c37ede54"];
+//    BerTlvs *result = [parser parseTlvs:testData error:nil];
+//    XCTAssertEqual([[result list] count], 0);
+//}
+
+- (void)testParseTlvsFromGarbageData {
+    NSArray *garbageDatas = @[[HexUtil parse:@"1c1308fd 11212a28"], [HexUtil parse:@"c8036f54"], [HexUtil parse:@"1f84f9fe"]];
+    
+    for (NSData *testData in garbageDatas) {
+        BerTlvParser *parser = [[BerTlvParser alloc] init];
+        BerTlvs *result = [parser parseTlvs:testData error:nil];
+        XCTAssertEqual([[result list] count], 0);
+    }
+}
+
+//- (void)testFuzzer {
+//    BerTlvParser *parser = [[BerTlvParser alloc] init];
+//
+//    NSInteger maxSize = 2048;
+//    NSInteger count = 1000; // increase this number to run the fuzzer longer.
+//    NSInteger failCount = 0;
+//
+//    for (NSInteger i = 0; i < count; i++) {
+//        NSInteger length = (arc4random() % maxSize) + 1; // +1 because zero length isn't too exciting.
+//        NSData * rndData = [self randomNSData:length];
+//        @try {
+//            [parser parseTlvs:rndData error:nil];
+//        }
+//        @catch (NSException * e) {
+//            XCTFail(@"crash %@, %@", rndData.description, e.name);
+//            failCount++;
+//        }
+//    }
+//    NSLog(@"fuzzer crashed %ld from %ld runs, with max length %ld", (long)failCount, (long)count, (long)maxSize);
+//}
+
+
+// MARK: Random data generator
+
+-(NSData*)randomNSData: (NSInteger)length
+{
+    NSMutableData* theData = [NSMutableData dataWithCapacity:length];
+    for( unsigned int i = 0 ; i < length/4 ; ++i )
+    {
+        u_int32_t randomBits = arc4random();
+        [theData appendBytes:(void*)&randomBits length:4];
+    }
+    return theData;
+}
+
+@end
+
+

--- a/BerTlvTests/BerTlvGarbageDataTests.m
+++ b/BerTlvTests/BerTlvGarbageDataTests.m
@@ -32,20 +32,22 @@
     XCTAssertNil(data);
 }
 
-//- (void)testCalcDataBadLength {
-//    BerTlvParser *parser = [[BerTlvParser alloc] init];
-//    NSData *testData = [HexUtil parse:@"ff20ffff0000"];
-//    BerTlvs *result = [parser parseTlvs:testData error:nil];
-//
-//    XCTAssertEqual([[result list] count], 0);
-//}
-//
-//- (void)testOutOfRange {
-//    BerTlvParser *parser = [[BerTlvParser alloc] init];
-//    NSData *testData = [HexUtil parse:@"3f9f5745 c37ede54"];
-//    BerTlvs *result = [parser parseTlvs:testData error:nil];
-//    XCTAssertEqual([[result list] count], 0);
-//}
+- (void)testCalcDataBadLength {
+    BerTlvParser *parser = [[BerTlvParser alloc] init];
+    NSData *testData = [HexUtil parse:@"ff20ffff0000"];
+    NSError *error;
+    [parser parseTlvs:testData error:&error];
+    XCTAssertNotNil(error);
+//    XCTAssertEqual([[result list] count], 0); // should a parsing error cause nil to be returned, or return a partial result?
+}
+
+- (void)testOutOfRange {
+    BerTlvParser *parser = [[BerTlvParser alloc] init];
+    NSData *testData = [HexUtil parse:@"3f9f5745 c37ede54"];
+    NSError *error;
+    [parser parseTlvs:testData error:&error];
+    XCTAssertNotNil(error);
+}
 
 - (void)testParseTlvsFromGarbageData {
     NSArray *garbageDatas = @[[HexUtil parse:@"1c1308fd 11212a28"], [HexUtil parse:@"c8036f54"], [HexUtil parse:@"1f84f9fe"]];
@@ -57,26 +59,29 @@
     }
 }
 
-//- (void)testFuzzer {
-//    BerTlvParser *parser = [[BerTlvParser alloc] init];
-//
-//    NSInteger maxSize = 2048;
-//    NSInteger count = 1000; // increase this number to run the fuzzer longer.
-//    NSInteger failCount = 0;
-//
-//    for (NSInteger i = 0; i < count; i++) {
-//        NSInteger length = (arc4random() % maxSize) + 1; // +1 because zero length isn't too exciting.
-//        NSData * rndData = [self randomNSData:length];
-//        @try {
-//            [parser parseTlvs:rndData error:nil];
-//        }
-//        @catch (NSException * e) {
-//            XCTFail(@"crash %@, %@", rndData.description, e.name);
-//            failCount++;
-//        }
-//    }
-//    NSLog(@"fuzzer crashed %ld from %ld runs, with max length %ld", (long)failCount, (long)count, (long)maxSize);
-//}
+- (void)testFuzzer {
+    BerTlvParser *parser = [[BerTlvParser alloc] init];
+
+    NSInteger maxSize = 2048;
+    NSInteger count = 1000; // increase this number to run the fuzzer longer.
+    NSInteger failCount = 0;
+
+    for (NSInteger i = 0; i < count; i++) {
+        NSDate *startTime = [NSDate date];
+        NSInteger length = (arc4random() % maxSize) + 1; // +1 because zero length isn't too exciting.
+        NSData * rndData = [self randomNSData:length];
+        @try {
+            [parser parseTlvs:rndData error:nil];
+        }
+        @catch (NSException * e) {
+            XCTFail(@"crash %@, %@", rndData.description, e.name);
+            failCount++;
+        }
+        double timePassed_ms = [startTime timeIntervalSinceNow] * -1000.0;
+        NSLog(@"Took %f", timePassed_ms);
+    }
+    NSLog(@"fuzzer crashed %ld from %ld runs, with max length %ld", (long)failCount, (long)count, (long)maxSize);
+}
 
 
 // MARK: Random data generator

--- a/BerTlvTests/BerTlvParserTests.m
+++ b/BerTlvTests/BerTlvParserTests.m
@@ -93,7 +93,7 @@ NSString *hexPrimitive =
 
     NSData *data = [HexUtil parse:hex];
     BerTlvParser *parser = [[BerTlvParser alloc] init];
-    BerTlv *tlv = [parser parseConstructed:data];
+    BerTlv *tlv = [parser parseConstructed:data error:nil];
     [self assertTag:[BerTag parse:@"e1"] actual:tlv.tag];
     XCTAssertTrue(3 == tlv.list.count, @"");
 
@@ -117,7 +117,7 @@ NSString *hexPrimitive =
 - (void) testParseTlvs {
     NSData *data = [HexUtil parse:hexPrimitive];
     BerTlvParser *parser = [[BerTlvParser alloc] init];
-    BerTlvs *tlvs = [parser parseTlvs:data];
+    BerTlvs *tlvs = [parser parseTlvs:data error:nil];
 
     XCTAssertEqual(31, tlvs.list.count, @"Count must be 13");
     NSLog(@"tlvs = \n%@", [tlvs dump:@"  "]);
@@ -128,7 +128,7 @@ NSString *hexPrimitive =
     NSData *data = [HexUtil parse:hexPrimitive];
     BerTlvParser *parser = [[BerTlvParser alloc] init];
 
-    BerTlvs *tlvs = [parser parseTlvs:data numberOfTags: 2];
+    BerTlvs *tlvs = [parser parseTlvs:data numberOfTags: 2 error:nil];
 
     XCTAssertEqual(2, tlvs.list.count, @"Count must be 2");
     NSLog(@"tlvs = \n%@", [tlvs dump:@"  "]);

--- a/BerTlvTests/BerTlvTests-Info.plist
+++ b/BerTlvTests/BerTlvTests-Info.plist
@@ -7,7 +7,7 @@
 	<key>CFBundleExecutable</key>
 	<string>${EXECUTABLE_NAME}</string>
 	<key>CFBundleIdentifier</key>
-	<string>com.payneteasy.${PRODUCT_NAME:rfc1034identifier}</string>
+	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
 	<key>CFBundleInfoDictionaryVersion</key>
 	<string>6.0</string>
 	<key>CFBundlePackageType</key>

--- a/BerTlvTests/BerTlvTests.m
+++ b/BerTlvTests/BerTlvTests.m
@@ -50,7 +50,7 @@
 
     NSData *data = [HexUtil parse:hex];
     BerTlvParser *parser = [[BerTlvParser alloc] init];
-    tlv = [parser parseConstructed:data];
+    tlv = [parser parseConstructed:data error:nil];
 
     TAG_DF7F   = [BerTag parse:@"DF 7F"];
     TAG_9F1E   = [BerTag parse:@"9F 1E"];
@@ -83,9 +83,9 @@
     [self assertString:@"4D3030302D4D5049" actual:[tlv find:TAG_DF0D].hexValue];
 }
 
-- (void)testIntValue {
+//- (void)testIntValue {
 //    XCTAssertEqual(5561998523279167561, [tlv find:TAG_DF0D].intValue);
-}
+//}
 
 
 - (void)assertString:(NSString *)aExpected actual:(NSString *)aActual {

--- a/BerTlvTests/BerTlvTests.m
+++ b/BerTlvTests/BerTlvTests.m
@@ -80,7 +80,7 @@
 }
 
 - (void)testHexValue {
-    [self assertString:@"4D3030302D4D5049" actual:[[tlv find:TAG_DF0D] hexValueWithError:nil]];
+    [self assertString:@"4D3030302D4D5049" actual:[[tlv find:TAG_DF0D] hexValue]];
 }
 
 //- (void)testIntValue {

--- a/BerTlvTests/BerTlvTests.m
+++ b/BerTlvTests/BerTlvTests.m
@@ -80,7 +80,7 @@
 }
 
 - (void)testHexValue {
-    [self assertString:@"4D3030302D4D5049" actual:[tlv find:TAG_DF0D].hexValue];
+    [self assertString:@"4D3030302D4D5049" actual:[[tlv find:TAG_DF0D] hexValueWithError:nil]];
 }
 
 //- (void)testIntValue {

--- a/BerTlvTests/BerTlvsTests.m
+++ b/BerTlvTests/BerTlvsTests.m
@@ -51,7 +51,7 @@
 
     NSData *data = [HexUtil parse:hex];
     BerTlvParser *parser = [[BerTlvParser alloc] init];
-    BerTlv *tlv = [parser parseConstructed:data];
+    BerTlv *tlv = [parser parseConstructed:data error:nil];
 
     TAG_DF7F   = [BerTag parse:@"DF 7F"];
     TAG_E1     = [BerTag parse:@"E1"];

--- a/BerTlvTests/HexUtilTests.m
+++ b/BerTlvTests/HexUtilTests.m
@@ -11,7 +11,6 @@
 #import "HexUtil.h"
 
 @interface HexUtilTests : XCTestCase
-
 @end
 
 @implementation HexUtilTests
@@ -31,10 +30,17 @@
     [self expected:@"F1F2F3F4F5F6F7F8F9FAFBFCFDFEFDFF" hex:@"f1f2f3f4f5f6f7f8f9fafbfcfdfefdff"];
 }
 
+- (void)testParseFailure {
+    [self expectErrorInvalidHex:@""];
+    [self expectErrorInvalidHex:@"a"];
+    [self expectErrorInvalidHex:@"123"];
+    [self expectErrorInvalidHex:@"a b c d e"];
+    [self expectErrorInvalidHex:@"zzzz"];
+}
+
 - (void)testPrettyFormat {
     [self prettyExpected:@"[6] 01 02 03 0A 0B 0C" hex:@"01 02 03 0a 0b 0c"];
 }
-
 
 - (void)expected:(NSString *)aHex {
     NSData *data = [HexUtil parse:aHex];
@@ -59,5 +65,12 @@
     XCTAssertTrue([aExpected isEqualToString:actual], @"Expected %@ but actual %@", aExpected, actual);
 }
 
+- (void)expectErrorInvalidHex:(NSString *)aHex {
+    NSError *error;
+    XCTAssertNil(error);
+    NSData *result = [HexUtil parse:aHex error:&error];
+    XCTAssertNil(result);
+    XCTAssertNotNil(error);
+}
 
 @end


### PR DESCRIPTION
Removed NSException based error handling, replaced it with NSError pointers.
Added obj-c nullability annotations to header files.
Allowed Xcode to perform it's recommended project file updates.

This causes breaking API changes.
Should keep the old API methods with Deprecated markers? One problem with this, although the methods will look the same, they won't behave the same.

This pull request got pretty big.