### PR TITLE
Additional error handling of BerTlvParser

### DIFF
--- a/BerTlv.xcodeproj/xcshareddata/xcschemes/BerTlv.xcscheme
+++ b/BerTlv.xcodeproj/xcshareddata/xcschemes/BerTlv.xcscheme
@@ -39,6 +39,16 @@
                ReferencedContainer = "container:BerTlv.xcodeproj">
             </BuildableReference>
          </TestableReference>
+         <TestableReference
+            skipped = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "8A4BEB5A198ED6C500707046"
+               BuildableName = "BerTlvTests.xctest"
+               BlueprintName = "BerTlvTests"
+               ReferencedContainer = "container:BerTlv.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
       </Testables>
       <MacroExpansion>
          <BuildableReference

--- a/BerTlv/BerTlvParser.m
+++ b/BerTlv/BerTlvParser.m
@@ -44,9 +44,10 @@ static int IS_DEBUG_ENABLED = 0; // note, running the testFuzzer unit test with 
     
     NSMutableArray *list = [[NSMutableArray alloc] init];
     uint offset = 0;
+    NSError * parseError = nil;
     for(uint i=0; i<numberOfTags; i++) {
         uint result=0;
-        BerTlv * ret = [self parseWithResult:&result data:aData offset:offset len:(uint)aData.length-offset level:0 error:error];
+        BerTlv * ret = [self parseWithResult:&result data:aData offset:offset len:(uint)aData.length-offset level:0 error:&parseError];
         
         if (ret != nil) {
             [list addObject:ret];
@@ -61,7 +62,10 @@ static int IS_DEBUG_ENABLED = 0; // note, running the testFuzzer unit test with 
 
         offset = result;
     }
-    if(*error){
+    if(parseError){
+        if(error){
+            *error=parseError;
+        }
         return nil;
     }
     return [[BerTlvs alloc] init:list];

--- a/BerTlv/BerTlvParser.m
+++ b/BerTlv/BerTlvParser.m
@@ -50,6 +50,9 @@ static int IS_DEBUG_ENABLED = 0; // note, running the testFuzzer unit test with 
         
         if (ret != nil) {
             [list addObject:ret];
+        } else
+        {
+            break;
         }
 
         if (result >= aData.length) {
@@ -58,7 +61,9 @@ static int IS_DEBUG_ENABLED = 0; // note, running the testFuzzer unit test with 
 
         offset = result;
     }
-
+    if(*error){
+        return nil;
+    }
     return [[BerTlvs alloc] init:list];
 }
 

--- a/BerTlv/BerTlvParser.m
+++ b/BerTlv/BerTlvParser.m
@@ -99,6 +99,7 @@ static int IS_DEBUG_ENABLED = 0; // note, running the testFuzzer unit test with 
     uint valueLength = [self calcDataLength:aBuf offset:aOffset + tagBytesCount error:&lengthErr];
     if (lengthErr && error) {
         *error = lengthErr;
+        return nil;
     }
 
     if(IS_DEBUG_ENABLED) {
@@ -107,6 +108,7 @@ static int IS_DEBUG_ENABLED = 0; // note, running the testFuzzer unit test with 
     }
 
     // VALUE
+    NSError * childError =nil;
     if(tag.isConstructed) {
         NSMutableArray *array = [[NSMutableArray alloc] init];
         [self addChildren:aBuf
@@ -117,8 +119,12 @@ static int IS_DEBUG_ENABLED = 0; // note, running the testFuzzer unit test with 
            dataBytesCount:lengthBytesCount
               valueLength:valueLength
                     array:array
-                    error:error
+                    error:&childError
         ];
+        if (childError && error) {
+            *error = childError;
+            return nil;
+        }
         uint resultOffset = aOffset + tagBytesCount + lengthBytesCount + valueLength;
         if(IS_DEBUG_ENABLED) {
             NSLog(@"%@Returning constructed offset = %d", levelPadding, resultOffset );
@@ -245,6 +251,9 @@ static int IS_DEBUG_ENABLED = 0; // note, running the testFuzzer unit test with 
     while (startPosition < aOffset + aValueLength) {
         uint result = 0;
         BerTlv *tlv = [self parseWithResult:&result data:aBuf offset:startPosition len:len level:aLevel+1 error:error];
+        if(*error){
+            break;
+        }
         if (tlv != nil) {
             [aList addObject:tlv];
         }

--- a/BerTlv/BerTlvParser.m
+++ b/BerTlv/BerTlvParser.m
@@ -122,6 +122,9 @@ static int IS_DEBUG_ENABLED = 0; // note, running the testFuzzer unit test with 
         *aOutResult = resultOffset;
         
         if (range.location + range.length > aBuf.length) {
+            if(error){
+                *error=[BerTlvErrors badLengthAtOffset:(uint)range.location numberOfBytes:range.length];
+            }
             return nil;
         }
         NSData *value = [aBuf subdataWithRange:range];;

--- a/BerTlvTests/BerTlvParserTests.m
+++ b/BerTlvTests/BerTlvParserTests.m
@@ -147,5 +147,15 @@ NSString * badLengthData = @"DF 01 06 AA BB CC DD EE"; // Truncated data, length
     XCTAssertNotNil(parseError);
 }
 
+- (void)testBadLengthTlvWithoutErrorParam{
+    NSData *data = [HexUtil parse:badLengthData error:nil];
+    
+    BerTlvParser *parser = [[BerTlvParser alloc] init];
+    BerTlvs *tlvs = [parser parseTlvs:data error:nil];
+    
+    XCTAssertNil(tlvs);
+
+}
+
 @end
 

--- a/BerTlvTests/BerTlvParserTests.m
+++ b/BerTlvTests/BerTlvParserTests.m
@@ -89,6 +89,8 @@ NSString *hexPrimitive =
 /*   f0 */ @"00 00 63                                            " // ..c
 ;
 
+NSString * badLengthData = @"DF 01 06 AA BB CC DD EE"; // Truncated data, length 06 but only 5 bytes value
+
 - (void)testParse {
 
     NSData *data = [HexUtil parse:hex error:nil];
@@ -132,6 +134,17 @@ NSString *hexPrimitive =
 
     XCTAssertEqual(2, tlvs.list.count, @"Count must be 2");
     NSLog(@"tlvs = \n%@", [tlvs dump:@"  "]);
+}
+
+- (void)testBadLengthTlv{
+    NSData *data = [HexUtil parse:badLengthData error:nil];
+
+    NSError * parseError =nil;
+    BerTlvParser *parser = [[BerTlvParser alloc] init];
+    BerTlvs *tlvs = [parser parseTlvs:data error:&parseError];
+
+    XCTAssertNil(tlvs);
+    XCTAssertNotNil(parseError);
 }
 
 @end


### PR DESCRIPTION
Hi,
and thanks for the good work. I've been using the framework for a while now, and I've found a few cases where either the NSError parameter wasn't set when nil was returned, or nil wasn't returned when the NSError parameter was assigned. I also found a place where broken data could cause an infinite loop when adding children. Hopefully I have not broken anything by my changes.

I also added a few negative tests.