### PR TITLE
Fixed bug where parser would ignore the last tags in constructed tag …

### DIFF
--- a/BerTlv/BerTlvParser.m
+++ b/BerTlv/BerTlvParser.m
@@ -248,7 +248,7 @@ static int IS_DEBUG_ENABLED = 0; // note, running the testFuzzer unit test with 
         return;
     }
     
-    while (startPosition < aOffset + aValueLength) {
+    while (startPosition < aOffset + aValueLength + aTagBytesCount + aDataBytesCount) {
         uint result = 0;
         BerTlv *tlv = [self parseWithResult:&result data:aBuf offset:startPosition len:len level:aLevel+1 error:error];
         if(*error){

--- a/BerTlvTests/BerTlvParserTests.m
+++ b/BerTlvTests/BerTlvParserTests.m
@@ -136,6 +136,19 @@ NSString * badLengthData = @"DF 01 06 AA BB CC DD EE"; // Truncated data, length
     NSLog(@"tlvs = \n%@", [tlvs dump:@"  "]);
 }
 
+- (void)testParseWholeConstructed {
+    // + [3F00]
+    //   - [01] 01
+    //   - [02] 0202
+    NSString *hex = @"3f00 8107 0101 0102 0202 02";
+    NSData *data = [HexUtil parse:hex error:nil];
+    BerTlvParser *parser = [[BerTlvParser alloc] init];
+    BerTlvs *tlvs = [parser parseTlvs:data error:nil];
+    BerTlv *tlv = [tlvs.list objectAtIndex:0];
+    XCTAssertEqual(2, tlv.list.count, @"Count must be 2");
+    NSLog(@"tlv = \n%@", [tlvs dump:@"  "]);
+}
+
 - (void)testBadLengthTlv{
     NSData *data = [HexUtil parse:badLengthData error:nil];
 


### PR DESCRIPTION
…in some cases if they are very small (1-2 bytes)

The length of the tag field and length field was not taken into account when parsing a constructed tag, resulting in a lost tag at the end if it consisted of very few bytes (1 to 2). 

I fixed this bug (and hopefully didn't break anything in the process), and also added a unit test that failed before the bug was fixed.

Thanks!